### PR TITLE
Made Rubocop-clean

### DIFF
--- a/_circleci_formatter.rb
+++ b/_circleci_formatter.rb
@@ -6,7 +6,7 @@ require 'time'
 
 # Copy of cucumber/formatter/json, with defensive Time.now handling
 module CircleCICucumberFormatter
-  class CircleCIJson < Cucumber::Formatter::GherkinFormatterAdapter
+  class CircleCIJson < Cucumber::Formatter::GherkinFormatterAdapter #:nodoc:
     include Cucumber::Formatter::Io
 
     alias_method :original_before_step, :before_step
@@ -19,8 +19,8 @@ module CircleCICucumberFormatter
       end
     end
 
-    def initialize(runtime, io, options)
-      @io = ensure_io(io, "json")
+    def initialize(_runtime, io, options)
+      @io = ensure_io(io, 'json')
       f = Gherkin::Formatter::JSONFormatter.new(@io)
       begin
         super(f, false, options)
@@ -37,11 +37,11 @@ module CircleCICucumberFormatter
 
     # used for capturing duration, copied from gherkin_formatter_adapter.rb
     # override step_finish with un-patched Time.now
-    def after_step(step)
+    def after_step(_step)
+      return if @outline && @options && @options[:expand] &&
+                !@in_instantiated_scenario
       step_finish = (unpatched_time_now - @step_time)
-      unless @outline and @options and @options[:expand] and not @in_instantiated_scenario
-        @gf.append_duration(step_finish)
-      end
+      @gf.append_duration(step_finish)
     end
   end
 end

--- a/test_output.rb
+++ b/test_output.rb
@@ -1,8 +1,9 @@
 #!/usr/bin/env ruby
 
-# takes two file names as arguments, expects first argument to be the unpatched json output
-# and second argument to be the patched json output
-# Checks that the times in the unpatched output are wrong and that the times in the patched output are correct.
+# takes two file names as arguments, expects first argument to be the unpatched
+# json output and second argument to be the patched json output
+# Checks that the times in the unpatched output are wrong and that the times in
+# the patched output are correct.
 
 require 'json'
 
@@ -10,13 +11,16 @@ broken_json = JSON.parse(File.read(ARGV[0]))
 fixed_json = JSON.parse(File.read(ARGV[1]))
 
 # durations are in nanoseconds
-broken_duration = broken_json[0]["elements"][0]["steps"][0]["result"]["duration"]
-fixed_duration = fixed_json[0]["elements"][0]["steps"][0]["result"]["duration"]
+broken_duration =
+  broken_json[0]['elements'][0]['steps'][0]['result']['duration']
+fixed_duration =
+  fixed_json[0]['elements'][0]['steps'][0]['result']['duration']
 
-if broken_duration < 1*36000*1E9
-  throw "broken duration isn't long enough (#{broken_duration}), the test is probably broken!"
+if broken_duration < 1 * 36_000 * 1E9
+  throw "broken duration isn't long enough (#{broken_duration}), the test is " \
+        'probably broken!'
 end
 
-if fixed_duration > 20*1E9 # give it a 10x margin (we sleep for 2 secs)
-  throw "fixed duration is too long, the patch is probably broken!"
+if fixed_duration > 20 * 1E9 # give it a 10x margin (we sleep for 2 secs)
+  throw 'fixed duration is too long, the patch is probably broken!'
 end


### PR DESCRIPTION
As mentioned in #1, Rubocop complains when run against a project on CircleCI because the formatter you embed is not Rubocop-clean.

This pull request fixes that by making your formatted Rubocop-clean.

We currently use Pronto to run Rubocop (as well as Brakeman and Rails Best Practices) against the latest commit and then separately run them all against the entire codebase on every commit with the following YAML:

``` yml
test:
  post:
    - COVERALLS_PARALLEL=true bundle exec rake coveralls:push:
        parallel: true
    - case $CIRCLE_NODE_INDEX in 0) bundle exec pronto run -f text -c origin/master --exit-code ;; 1) bundle exec pronto run -f github -c origin/master ;; esac:
        parallel: true
    - case $CIRCLE_NODE_INDEX in 0) bundle exec brakeman --exit-on-warn ;; 1) bundle exec rubocop -D --format offenses --format progress ;; 2) bundle exec rails_best_practices --features --spec ;; esac:
        parallel: true
```
