### PR TITLE
Update the formatter to include logic for both Cucumber 1.3 and 2.*

### DIFF
--- a/_circleci_formatter.rb
+++ b/_circleci_formatter.rb
@@ -1,47 +1,79 @@
-require 'cucumber/formatter/gherkin_formatter_adapter'
-require 'cucumber/formatter/io'
-require 'gherkin/formatter/argument'
-require 'gherkin/formatter/json_formatter'
 require 'time'
 
-# Copy of cucumber/formatter/json, with defensive Time.now handling
-module CircleCICucumberFormatter
-  class CircleCIJson < Cucumber::Formatter::GherkinFormatterAdapter #:nodoc:
-    include Cucumber::Formatter::Io
+if Cucumber::VERSION =~ /^2.*/
+  require 'cucumber/core/test/timer'
+  require 'cucumber/formatter/json'
+  module Cucumber
+    module Core
+      module Test
+        class Timer
+          def unpatched_time_now
+            if Time.respond_to?(:now_without_mock_time)
+              Time.now_without_mock_time
+            else
+              Time.now
+            end
+          end
 
-    alias_method :original_before_step, :before_step
-
-    def unpatched_time_now
-      if Time.respond_to?(:now_without_mock_time)
-        Time.now_without_mock_time
-      else
-        Time.now
+          def time_in_nanoseconds
+            t = unpatched_time_now
+            t.to_i * 10 ** 9 + t.nsec
+          end
+        end
       end
-    end
-
-    def initialize(_runtime, io, options)
-      @io = ensure_io(io, 'json')
-      f = Gherkin::Formatter::JSONFormatter.new(@io)
-      begin
-        super(f, false, options)
-      rescue ArgumentError # backwards compatibility with old arity
-        super(f, false)
-      end
-    end
-
-    # override @step_time with un-patched Time.now
-    def before_step(step)
-      original_before_step(step)
-      @step_time = unpatched_time_now
-    end
-
-    # used for capturing duration, copied from gherkin_formatter_adapter.rb
-    # override step_finish with un-patched Time.now
-    def after_step(_step)
-      return if @outline && @options && @options[:expand] &&
-                !@in_instantiated_scenario
-      step_finish = (unpatched_time_now - @step_time)
-      @gf.append_duration(step_finish)
     end
   end
-end
+
+  module CircleCICucumberFormatter
+    class CircleCIJson < Cucumber::Formatter::Json #:nodoc:
+    end
+  end
+end # if
+
+if Cucumber::VERSION =~ /^1.*/
+  require 'cucumber/formatter/gherkin_formatter_adapter'
+  require 'cucumber/formatter/io'
+  require 'gherkin/formatter/argument'
+  require 'gherkin/formatter/json_formatter'
+
+  module CircleCICucumberFormatter
+    class CircleCIJson < Cucumber::Formatter::GherkinFormatterAdapter #:nodoc:
+      include Cucumber::Formatter::Io
+
+      alias_method :original_before_step, :before_step
+
+      def unpatched_time_now
+        if Time.respond_to?(:now_without_mock_time)
+          Time.now_without_mock_time
+        else
+          Time.now
+        end
+      end
+
+      def initialize(_runtime, io, options)
+        @io = ensure_io(io, 'json')
+        f = Gherkin::Formatter::JSONFormatter.new(@io)
+        begin
+          super(f, false, options)
+        rescue ArgumentError # backwards compatibility with old arity
+          super(f, false)
+        end
+      end
+
+      # override @step_time with un-patched Time.now
+      def before_step(step)
+        original_before_step(step)
+        @step_time = unpatched_time_now
+      end
+
+      # used for capturing duration, copied from gherkin_formatter_adapter.rb
+      # override step_finish with un-patched Time.now
+      def after_step(_step)
+        return if @outline && @options && @options[:expand] &&
+                  !@in_instantiated_scenario
+        step_finish = (unpatched_time_now - @step_time)
+        @gf.append_duration(step_finish)
+      end
+    end
+  end # module
+end # if

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+machine:
+  environment:
+    ruby: 2.1.5
+
 test:
   override:
     - ./test.sh


### PR DESCRIPTION
There has been a significant change in project structure between Cucumber 1.3 and 2.*, so I decided to go with the branched flow for now.

In 2.*, the logic for test step hash creation was moved to the `cucumber-core` gem, and the `gherkin` dependency was removed from `cucumber-ruby` gem, therefore the old approach to altering the formatter doesn’t work with the new cucumber versions.

In 1.3, the old formatter still works well.

Set up testing for the four most recent versions of Cucumber—1.3, 2.1, 2.2 and 2.3.
### Context

Timecop overrides `Time.now`, and `Time.now` is used for determining the `duration` field in the JSON generated by Cucumber. For example [here](https://github.com/cucumber/cucumber-ruby-core/blob/master/lib/cucumber/core/test/timer.rb#L27).

By working around Timecop we ensure that `duration` is calculated correctly in all cases and that using Timecop does not break the automatic test balancing for Cucumber tests.
