### PR TITLE
Add support for cucumber 3.x

### DIFF
--- a/_circleci_formatter.rb
+++ b/_circleci_formatter.rb
@@ -1,5 +1,35 @@
 require 'time'
 
+if Cucumber::VERSION =~ /^3.*/
+  require 'cucumber/core/test/timer'
+  require 'cucumber/formatter/pretty'
+  module Cucumber
+    module Core
+      module Test
+        class Timer
+          def unpatched_time_now
+            if Time.respond_to?(:now_without_mock_time)
+              Time.now_without_mock_time
+            else
+              Time.now
+            end
+          end
+
+          def time_in_nanoseconds
+            t = unpatched_time_now
+            t.to_i * 10 ** 9 + t.nsec
+          end
+        end
+      end
+    end
+  end
+
+  module CircleCICucumberFormatter
+    class CircleCIJson < Cucumber::Formatter::Pretty #:nodoc:
+    end
+  end
+end # if
+
 if Cucumber::VERSION =~ /^2.*/
   require 'cucumber/core/test/timer'
   require 'cucumber/formatter/json'

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,7 @@ mkdir -p gemfiles
 mkdir $CIRCLE_ARTIFACTS/broken
 mkdir $CIRCLE_ARTIFACTS/fixed
 
-versions=( "2.3.2" "2.2.0" "2.1.0" "1.3.20" )
+versions=( "3.0.1" "2.3.2" "2.2.0" "2.1.0" "1.3.20" )
 
 for v in "${versions[@]}"
 do


### PR DESCRIPTION
Add support for cucumber 3.x on CircleCI by changing the formatter.

This runs the tests in CircleCI.

Running `sh test.sh` still exits with code `1` as it's due to the `warning` message from cucumber:
`WARNING: The formatter CircleCICucumberFormatter::CircleCIJson is using the deprecated formatter API which will be removed in v4.0 of Cucumber.`

This is because I believe they are moving away from JSON formatters in 4.x